### PR TITLE
hashRound2 only needs to output 4 bytes

### DIFF
--- a/NaclKeys/KeyGenerator.cs
+++ b/NaclKeys/KeyGenerator.cs
@@ -331,7 +331,7 @@ namespace NaclKeys
                     string.Format("key must be {0} bytes in length.", PublicKeyBytes));
 
             var hashRound1 = GenericHash.Hash(ArrayHelpers.ConcatArrays(version, publicKey), null, 64);
-            var hashRound2 = GenericHash.Hash(hashRound1, null, 64);
+            var hashRound2 = GenericHash.Hash(hashRound1, null, 16);
 
             var result = new byte[4];
             Buffer.BlockCopy(hashRound2, 0, result, 0, result.Length);

--- a/Tests/BytejailTests.cs
+++ b/Tests/BytejailTests.cs
@@ -14,7 +14,7 @@ namespace Tests
         [Test]
         public void GenerateBytejailKeyPairTest()
         {
-            const string expected = "2PNPvrfYAQxhaGYaAzsWTYgEzymmQZ37jG2vJThBJHDcY4SABnH";
+            const string expected = "2PNPvrfYAQxhaGYaAzsWTYgEzymmQZ37jG2vJThBJHDcY6NzNoK";
             const string userInputPartOne = "someone@example.com";
             const string userInputPartTwo = "magnetometers payee induce tangibly polonaises unrestricted oilfield";
             Console.WriteLine("--- Generate bytejail KeyPair start ---");
@@ -38,7 +38,7 @@ namespace Tests
         [Test]
         public void GenerateBytejailKeyPairExaggeratedTest()
         {
-            const string expected = "2NjStPkM3Wr2JwqmH7gG7sRUhyGVG2FFewUajjbHrWRvjDtLqwB";
+            const string expected = "2NjStPkM3Wr2JwqmH7gG7sRUhyGVG2FFewUajjbHrWRvjD5dpU3";
             // Test with KeePass generated inputs: length of 1024 exclude " and \
             const string userInputPartOne =
                 "s7MgHRz?|dP@mmD7Q#Y~:m[]~Sjy7ad)t`tO&61B@o8l9p+['.V}y{L~])z{KM*:Cr8iw2t63^bpyn]b+x8Hh5#UG^gu>y1JgVj:4]NkYR<aE+T1C/3EaC9xxL#`n:=c0^_|eZm%-5T^yOM5DI9 ,XcG!Ej5=IuV0/j>bsYM'x[hQY#uwqNkm?0emxikBM$NHyzi9SLVd?E[)9x=.]d)f,]+9;;LJx|$ki|O-7PvZR/tF}9L&Hn!whdoklx+cyGiKCh=$qfXC9nuu;!21b=)as;R$%[d4[VESbTZ<tVMiZyT0|wDSCZTLT9v`QRg[6]m0Vgr]Ps@bp`J&P_4tfv:rJJ*P.z-!=]Nc07UwfUq2,C:vI1`LHrb$>ooM_S7{Lby/awngY9TMKAi[vj+V0u6'ot&gC?@6PtUP$8*iTeP`|~|)5^Y-_Nc@1]1jJO-.3+`r<BPFuDzah'H334*M^^8g;?v{9)P,=R[Uw*$D]w#oZm6yZ}c:5V^.*(F8S{?x!s#{)UL-}`VMdg:Y6Z]KE8%tjsE;Y)w+G>S@'K1Sf;]8<$`@Novad[whD.rahiJdfPetl`9 A)DH ZupA*6FIwU8n6Fa~Wf_-an*Etny9>GH}+5+F2!Y*?gD <P~`b~)xm~+9&2X;#K[iPj%F8.M/9/ifi?l1 )buY%2cIf,Rf/]NLgKoszB^ p$jmww1yfU)+lu#E-|)0lG7V{C!?]T`2cO/.k 3=C .`xcx&k sT1b&/.(8/Za)qO5w4)hDz'~tO]Y{ueGG[<<[L@kt1W~>Ct0ZsQNF{3RI!mIxS?L8CUTOEXxroeMhK;'p8xQ-_0Qr^St+0vJ;]#,?*0#F5146lN7MMQXN7b@Z)I>BQQ8S2'_WiBn)r$?Q~IE[)~b*`a8H8Y u`i4m# k^Z6%nk^.V_n5N?M.TS@?G=uE:%fpvhE8:)|Bm.fK.1w2|?Y}tpa)XuuhGt0DeWijlee2:8BqTNK2GDr!i2_M_?NnD2T{@G*Yc'gZ2Up(9}5]/NYd%^T$|0_";


### PR DESCRIPTION
I would have suggested changing it to simply 4, but [libsodium-net doesn't allow a generichash result of less than 16 bytes](https://github.com/adamcaudill/libsodium-net/blob/fad149e1b9d7d73f5daa6ab24f243927a2fa6bf6/libsodium-net/GenericHash.cs#L80).

This appears be an inconsequential change, especially from a security perspective, but optimistically you save a few CPU cycles and have a smaller memory footprint.
